### PR TITLE
Fixes #24

### DIFF
--- a/app/models/decidim/collaborations/abilities/current_user_ability.rb
+++ b/app/models/decidim/collaborations/abilities/current_user_ability.rb
@@ -17,7 +17,7 @@ module Decidim
 
           can :donate, Collaboration do |collaboration|
             collaboration.accepts_donations? &&
-              current_settings.collaborations_allowed? &&
+              current_settings&.collaborations_allowed? &&
               Census::API::Totals.user_totals(user.id) < Decidim::Collaborations.maximum_annual_collaboration
           end
 

--- a/app/models/decidim/collaborations/abilities/guest_user_ability.rb
+++ b/app/models/decidim/collaborations/abilities/guest_user_ability.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Collaborations
+    module Abilities
+      # Defines the abilities for guest users..
+      # Intended to be used with `cancancan`.
+      class GuestUserAbility
+        include CanCan::Ability
+
+        attr_reader :context
+
+        def initialize(user, context)
+          return if user
+
+          @context = context
+
+          can :donate, Collaboration do |collaboration|
+            collaboration.accepts_donations? &&
+              current_settings&.collaborations_allowed?
+          end
+        end
+
+        private
+
+        def current_settings
+          @context.fetch(:current_settings, nil)
+        end
+      end
+    end
+  end
+end

--- a/app/views/decidim/collaborations/collaborations/_sign_in.html.erb
+++ b/app/views/decidim/collaborations/collaborations/_sign_in.html.erb
@@ -1,0 +1,8 @@
+<div class="definition-data__item vote-block">
+  <% if can? :donate, collaboration %>
+    <%= action_authorized_link_to :donate, collaboration_path(collaboration),
+                                  class: "card__button button expanded button--sc" do %>
+      <%= t('.donate') %>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/decidim/collaborations/collaborations/_sign_in.html.erb
+++ b/app/views/decidim/collaborations/collaborations/_sign_in.html.erb
@@ -1,8 +1,8 @@
-<div class="definition-data__item vote-block">
-  <% if can? :donate, collaboration %>
+<% if can? :donate, collaboration %>
+  <div class="definition-data__item sign-in-block">
     <%= action_authorized_link_to :donate, collaboration_path(collaboration),
                                   class: "card__button button expanded button--sc" do %>
       <%= t('.donate') %>
     <% end %>
-  <% end %>
-</div>
+  </div>
+<% end %>

--- a/app/views/decidim/collaborations/collaborations/show.html.erb
+++ b/app/views/decidim/collaborations/collaborations/show.html.erb
@@ -8,6 +8,8 @@
     <%= render 'decidim/collaborations/collaborations/totals', user: nil %>
     <% if user_signed_in? %>
       <%= render 'decidim/collaborations/collaborations/totals', user: current_user %>
+    <% else %>
+      <%= render 'decidim/collaborations/collaborations/sign_in', collaboration: collaboration %>
     <% end %>
   </div>
 
@@ -18,7 +20,7 @@
     <div class="section">
       <%= sanitize translated_attribute collaboration.description %>
     </div>
-    <% if can? :donate, collaboration %>
+    <% if user_signed_in? && can?(:donate, collaboration) %>
       <%= render 'decidim/collaborations/collaborations/terms_and_conditions' %>
       <div class="section">
         <%= render 'decidim/collaborations/collaborations/donate_form' %>

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -140,6 +140,8 @@ ca:
           select_frequency: Sel·lecciona la frequència
           select_payment_method: Sel·lecciona la forma de pagament
           donate: Donar suport
+        sign_in:
+          donate: Donar suport
       user_collaborations:
         create:
           invalid: L'operació ha fallat.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -140,6 +140,8 @@ en:
           select_frequency: Select the frequency
           select_payment_method: Select the payment method
           donate: Support
+        sign_in:
+          donate: Support
       user_collaborations:
         create:
           invalid: Operation failed.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -140,6 +140,8 @@ es:
           select_frequency: Seleccciona la frequencia
           select_payment_method: Selecciona la forma de pago
           donate: Apoyar
+        sign_in:
+          donate: Apoyar
       user_collaborations:
         create:
           invalid: Falló la operación.

--- a/lib/decidim/collaborations/engine.rb
+++ b/lib/decidim/collaborations/engine.rb
@@ -30,6 +30,7 @@ module Decidim
         Decidim.configure do |config|
           config.abilities += %w[
             Decidim::Collaborations::Abilities::CurrentUserAbility
+            Decidim::Collaborations::Abilities::GuestUserAbility
           ]
         end
       end

--- a/spec/models/decidim/collaborations/abilities/guest_user_ability_spec.rb
+++ b/spec/models/decidim/collaborations/abilities/guest_user_ability_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'cancan/matchers'
+
+describe Decidim::Collaborations::Abilities::GuestUserAbility do
+  let(:current_settings) { {} }
+  let(:collaborations_allowed) { true }
+  let(:collaboration) { create(:collaboration) }
+
+  subject { described_class.new(nil, current_settings: current_settings) }
+
+  before do
+    expect(current_settings).to receive(:collaborations_allowed?)
+                                  .at_most(:once)
+                                  .and_return(collaborations_allowed)
+  end
+
+  context 'donate to collaboration' do
+    context 'collaboration allowed' do
+      let(:collaborations_allowed) { true }
+
+      it 'let the user donate when collaboration accepts donations' do
+        expect(collaboration).to receive(:accepts_donations?).and_return(true)
+        expect(subject).to be_able_to(:donate, collaboration)
+      end
+
+      it 'Do not let the user donate when collaboration do not accepts donations' do
+        expect(collaboration).to receive(:accepts_donations?).and_return(false)
+        expect(subject).not_to be_able_to(:donate, collaboration)
+      end
+    end
+
+    context 'collaboration not allowed' do
+      let(:collaborations_allowed) { false }
+
+      it 'do not let the user donate when collaboration accepts donations' do
+        expect(collaboration).to receive(:accepts_donations?).and_return(true)
+        expect(subject).not_to be_able_to(:donate, collaboration)
+      end
+
+      it 'Do not let the user donate when collaboration do not accepts donations' do
+        expect(collaboration).to receive(:accepts_donations?).and_return(false)
+        expect(subject).not_to be_able_to(:donate, collaboration)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Guest users will see a 'collaborate' button that redirects them to the sign in dialog in case the collaboration campaign still accepts supports.