### PR TITLE
Fixes #25

### DIFF
--- a/app/views/decidim/collaborations/collaborations/show.html.erb
+++ b/app/views/decidim/collaborations/collaborations/show.html.erb
@@ -23,6 +23,12 @@
       <div class="section">
         <%= render 'decidim/collaborations/collaborations/donate_form' %>
       </div>
+    <% else %>
+      <% if user_signed_in? %>
+        <div class="callout alert">
+          <%= donate_status_message %>
+        </div>
+      <% end %>
     <% end %>
   </div>
 </div>

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -62,6 +62,11 @@ ca:
           monthly: Mensual
           quarterly: Trimestral
           annual: Anual
+        donate_status:
+          collaboration_not_allowed: La col·laboració no está permesa en estos moments.
+          maximum_annual_exceeded: No pots realitzar mes col·laboracions. Has arribat al màxim anual permés.
+          support_period_finished: El periode per a realitzar colaboracions ha finalitzat.
+          objective_reached: S'ha assolit l'objectiu per a la campanya. No s'admeten més col·laboracions.
         payment_method_types:
           existing_payment_method: Forma de pagament existent
           direct_debit: Dèbit directe

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -62,6 +62,11 @@ en:
           monthly: Monthly
           quarterly: Quarterly
           annual: Annual
+        donate_status:
+          collaboration_not_allowed: Collaboration is not allowed at this moment.
+          maximum_annual_exceeded: You can not create more collaborations. You have reached the maximum yearly allowed.
+          support_period_finished: The period for accepting collaborations has expired.
+          objective_reached: The target amount has been reached. This campaign do not accepts more collaborations.
         payment_method_types:
           existing_payment_method: Existing payment method
           direct_debit: Direct debit

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -62,6 +62,11 @@ es:
           monthly: Mensual
           quarterly: Trimestral
           annual: Anual
+        donate_status:
+          collaboration_not_allowed: La colaboración no está permitida en estos momentos.
+          maximum_annual_exceeded: No puedes realizar mas colaboraciones. Has alcanzado el máximo anual permitido.
+          support_period_finished: El periodo para realizar colaboraciones ha concluido.
+          objective_reached: Se ha alcanzado el objetivo para la campaña. No se admiten mas colaboraciones.
         payment_method_types:
           existing_payment_method: Método de pago existente
           direct_debit: Débito directo

--- a/spec/features/decidim/collaborations/collaboration_status_message_spec.rb
+++ b/spec/features/decidim/collaborations/collaboration_status_message_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'Collaborations view', type: :feature do
+  include_context 'feature'
+  let(:manifest_name) { 'collaborations' }
+  let(:active_until) { nil }
+  let!(:collaboration) do
+    create(:collaboration, feature: feature, active_until: active_until)
+  end
+  let(:user) { create(:user, :confirmed, organization: organization) }
+
+  before do
+    login_as(user, scope: :user)
+  end
+
+  context 'Census API is down' do
+    before do
+      stub_totals_service_down
+      visit_feature
+    end
+
+    it 'Gives feedback about status' do
+      expect(page).to have_content('Collaboration is not allowed at this moment.')
+    end
+  end
+
+  context 'User has reached his maximum per year' do
+    before do
+      allow(Census::API::Totals).to receive(:campaign_totals).with(collaboration.id).and_return(0)
+      allow(Census::API::Totals).to receive(:user_totals)
+                                .with(user.id)
+                                .and_return(Decidim::Collaborations.maximum_annual_collaboration)
+      allow(Census::API::Totals).to receive(:user_campaign_totals)
+                                      .with(user.id, collaboration.id)
+                                      .and_return(0)
+      visit_feature
+    end
+
+    it 'Gives feedback about status' do
+      expect(page).to have_content('You can not create more collaborations. You have reached the maximum yearly allowed.')
+    end
+  end
+
+  context 'Target amount reached' do
+    before do
+      allow(Census::API::Totals).to receive(:campaign_totals)
+                                      .with(collaboration.id)
+                                      .and_return(collaboration.target_amount)
+      allow(Census::API::Totals).to receive(:user_totals)
+                                      .with(user.id)
+                                      .and_return(0)
+
+      allow(Census::API::Totals).to receive(:user_campaign_totals)
+                                      .with(user.id, collaboration.id)
+                                      .and_return(0)
+      visit_feature
+    end
+
+    it 'Gives feedback about status' do
+      expect(page).to have_content('The target amount has been reached. This campaign do not accepts more collaborations.')
+    end
+  end
+
+  context 'Out of collaboration period' do
+    let(:active_until) { Date.today - 1.day }
+
+    before do
+      stub_totals_request(0)
+      visit_feature
+    end
+
+    it 'Gives feedback about status' do
+      expect(page).to have_content('The period for accepting collaborations has expired.')
+    end
+  end
+end


### PR DESCRIPTION
Status message is shown when collaboration is not allowed.

#### :tophat: What? Why?

Previous version was showing nothing when collaboration was now allowed. This pull request adds a status message when collaboration is not allowed. This way the user receives feedback about the reasons why he can support a campaign.

#### :pushpin: Related Issues
- Fixes #25 
