### PR TITLE
Fixes #10

### DIFF
--- a/app/assets/stylesheets/decidim/collaborations/_user_collaboration.scss
+++ b/app/assets/stylesheets/decidim/collaborations/_user_collaboration.scss
@@ -1,4 +1,4 @@
-.donate {
+.support {
   color: white !important;
   text-transform: uppercase;
   font-weight: bold;

--- a/app/controllers/concerns/decidim/collaborations/needs_collaboration.rb
+++ b/app/controllers/concerns/decidim/collaborations/needs_collaboration.rb
@@ -14,7 +14,7 @@ module Decidim
       def self.enhance_controller(instance_or_module)
         instance_or_module.class_eval do
           helper_method :collaboration
-          helper_method :donate_status_message
+          helper_method :support_status_message
 
           helper Decidim::Collaborations::Admin::CollaborationsHelper
           helper Decidim::Collaborations::CollaborationsHelper
@@ -32,20 +32,20 @@ module Decidim
         end
 
         # Public: Returns the reason why collaboration is not allowed.
-        def donate_status_message
+        def support_status_message
           if maximum_per_year_reached?
-            return I18n.t 'decidim.collaborations.labels.donate_status.maximum_annual_exceeded'
+            return I18n.t 'decidim.collaborations.labels.support_status.maximum_annual_exceeded'
           end
 
           if target_amount_reached?
-            return I18n.t 'decidim.collaborations.labels.donate_status.objective_reached'
+            return I18n.t 'decidim.collaborations.labels.support_status.objective_reached'
           end
 
           if out_of_collaboration_period?
-            return I18n.t 'decidim.collaborations.labels.donate_status.support_period_finished'
+            return I18n.t 'decidim.collaborations.labels.support_status.support_period_finished'
           end
 
-          I18n.t 'decidim.collaborations.labels.donate_status.collaboration_not_allowed'
+          I18n.t 'decidim.collaborations.labels.support_status.collaboration_not_allowed'
         end
 
         private

--- a/app/controllers/decidim/collaborations/collaborations_controller.rb
+++ b/app/controllers/decidim/collaborations/collaborations_controller.rb
@@ -29,7 +29,7 @@ module Decidim
 
       def initialize_form_defaults
         @form.amount = collaboration.default_amount
-        @form.frequency = if collaboration.recurrent_donation_allowed?
+        @form.frequency = if collaboration.recurrent_support_allowed?
                             Decidim::Collaborations.default_frequency
                           else
                             'punctual'

--- a/app/models/census/api/totals.rb
+++ b/app/models/census/api/totals.rb
@@ -30,7 +30,7 @@ module Census
       end
 
       # PUBLIC Return User totals in the context of the given campaign.
-      # Returns the amount donated by the user for the given campaign. Nil in
+      # Returns the amount supported by the user for the given campaign. Nil in
       # case an error occurs.
       def self.user_campaign_totals(user_id, campaign_id)
         response = totals_request(person_id: user_id, campaign_code: campaign_id)

--- a/app/models/decidim/collaborations/abilities/current_user_ability.rb
+++ b/app/models/decidim/collaborations/abilities/current_user_ability.rb
@@ -15,15 +15,15 @@ module Decidim
           @user = user
           @context = context
 
-          can :donate, Collaboration do |collaboration|
-            collaboration.accepts_donations? &&
-              current_settings&.collaborations_allowed? &&
+          can :support, Collaboration do |collaboration|
+            collaboration.accepts_supports? &&
+              current_settings.collaborations_allowed? &&
               Census::API::Totals.user_totals(user.id) < Decidim::Collaborations.maximum_annual_collaboration
           end
 
-          can :donate_recurrently, Collaboration do |collaboration|
-            collaboration.recurrent_donation_allowed? &&
-              collaboration.user_collaborations.donated_by(user).none?
+          can :support_recurrently, Collaboration do |collaboration|
+            collaboration.recurrent_support_allowed? &&
+              collaboration.user_collaborations.supported_by(user).none?
           end
         end
 

--- a/app/models/decidim/collaborations/abilities/guest_user_ability.rb
+++ b/app/models/decidim/collaborations/abilities/guest_user_ability.rb
@@ -15,8 +15,8 @@ module Decidim
 
           @context = context
 
-          can :donate, Collaboration do |collaboration|
-            collaboration.accepts_donations? &&
+          can :support, Collaboration do |collaboration|
+            collaboration.accepts_supports? &&
               current_settings&.collaborations_allowed?
           end
         end

--- a/app/models/decidim/collaborations/collaboration.rb
+++ b/app/models/decidim/collaborations/collaboration.rb
@@ -23,8 +23,8 @@ module Decidim
         @total_collected ||= Census::API::Totals.campaign_totals(id)
       end
 
-      # PUBLIC Returns true if the collaboration campaign accepts donations.
-      def accepts_donations?
+      # PUBLIC Returns true if the collaboration campaign accepts supports.
+      def accepts_supports?
         collected = total_collected || target_amount
 
         feature.participatory_space.published? &&
@@ -32,7 +32,7 @@ module Decidim
           (target_amount > collected)
       end
 
-      # PUBLIC returns the percentage of funds donated with regards to
+      # PUBLIC returns the percentage of funds supported with regards to
       # the total collected
       def percentage
         census_total_collected = total_collected
@@ -43,7 +43,7 @@ module Decidim
         result
       end
 
-      # PUBLIC returns the percentage of funds donated by a user
+      # PUBLIC returns the percentage of funds supported by a user
       # with regards to the total collected.
       def user_percentage(user)
         census_user_total_collected = user_total_collected(user)
@@ -54,13 +54,13 @@ module Decidim
         result
       end
 
-      # PUBLIC returns the amount donated by a user
+      # PUBLIC returns the amount supported by a user
       def user_total_collected(user)
         Census::API::Totals.user_campaign_totals(user.id, id)
       end
 
-      # PUBLIC returns whether recurrent donations are allowed or not.
-      def recurrent_donation_allowed?
+      # PUBLIC returns whether recurrent supports are allowed or not.
+      def recurrent_support_allowed?
         feature&.participatory_space_type == 'Decidim::Assembly'
       end
     end

--- a/app/models/decidim/collaborations/user_collaboration.rb
+++ b/app/models/decidim/collaborations/user_collaboration.rb
@@ -21,7 +21,7 @@ module Decidim
         greater_than: 0
       }
 
-      scope :donated_by, ->(user) { where(user: user) }
+      scope :supported_by, ->(user) { where(user: user) }
       scope :is_accepted, -> { where(state: 'accepted') }
       scope :monthly_frequency, lambda {
         where(frequency: 'monthly')

--- a/app/views/decidim/collaborations/collaborations/_collaboration.html.erb
+++ b/app/views/decidim/collaborations/collaborations/_collaboration.html.erb
@@ -9,8 +9,8 @@
     </div>
   </div>
   <div class="card--list__data collaboration-list__data">
-    <% if can? :donate, collaboration %>
-      <%= link_to t('.donate'), collaboration, class: 'button tiny hollow collaboration--list__action' %>
+    <% if can? :support, collaboration %>
+      <%= link_to t('.support'), collaboration, class: 'button tiny hollow collaboration--list__action' %>
     <% end %>
     <span class="card--list__data__number collaboration-list__number">
       <%= total_collected_to_currency(collaboration.total_collected) %>

--- a/app/views/decidim/collaborations/collaborations/_sign_in.html.erb
+++ b/app/views/decidim/collaborations/collaborations/_sign_in.html.erb
@@ -1,8 +1,8 @@
-<% if can? :donate, collaboration %>
+<% if can? :support, collaboration %>
   <div class="definition-data__item sign-in-block">
-    <%= action_authorized_link_to :donate, collaboration_path(collaboration),
+    <%= action_authorized_link_to :support, collaboration_path(collaboration),
                                   class: "card__button button expanded button--sc" do %>
-      <%= t('.donate') %>
+      <%= t('.support') %>
     <% end %>
   </div>
 <% end %>

--- a/app/views/decidim/collaborations/collaborations/_support_form.html.erb
+++ b/app/views/decidim/collaborations/collaborations/_support_form.html.erb
@@ -8,9 +8,9 @@
   </div>
 
   <h2 class=section-heading><%=t '.select_amount' %></h2>
-  <%= f.donate_tag :amount, collaboration.amounts %>
+  <%= f.support_tag :amount, collaboration.amounts %>
 
-  <% if can? :donate_recurrently, collaboration %>
+  <% if can? :support_recurrently, collaboration %>
     <br>
     <h2 class=section-heading><%=t '.select_frequency' %></h2>
     <div class="radio-selector">
@@ -51,7 +51,7 @@
   <% end %>
 
   <div class="form-general-submit">
-    <%= f.submit t('.donate'), class: 'button secondary donate' %>
+    <%= f.submit t('.support'), class: 'button secondary support' %>
   </div>
 <% end %>
 

--- a/app/views/decidim/collaborations/collaborations/show.html.erb
+++ b/app/views/decidim/collaborations/collaborations/show.html.erb
@@ -20,7 +20,7 @@
     <div class="section">
       <%= sanitize translated_attribute collaboration.description %>
     </div>
-    <% if user_signed_in? && can?(:donate, collaboration) %>
+    <% if user_signed_in? && can?(:support, collaboration) %>
       <%= render 'decidim/collaborations/collaborations/terms_and_conditions' %>
       <div class="section">
         <%= render 'decidim/collaborations/collaborations/support_form' %>
@@ -28,7 +28,7 @@
     <% else %>
       <% if user_signed_in? %>
         <div class="callout alert">
-          <%= donate_status_message %>
+          <%= support_status_message %>
         </div>
       <% end %>
     <% end %>

--- a/app/views/decidim/collaborations/collaborations/show.html.erb
+++ b/app/views/decidim/collaborations/collaborations/show.html.erb
@@ -23,7 +23,7 @@
     <% if user_signed_in? && can?(:donate, collaboration) %>
       <%= render 'decidim/collaborations/collaborations/terms_and_conditions' %>
       <div class="section">
-        <%= render 'decidim/collaborations/collaborations/donate_form' %>
+        <%= render 'decidim/collaborations/collaborations/support_form' %>
       </div>
     <% else %>
       <% if user_signed_in? %>

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -44,7 +44,7 @@ ca:
         accept_terms_and_conditions: Accepte els termes i condicions
   decidim:
     form_builder:
-      donate_tag:
+      support_tag:
         other: Altres
     features:
       collaborations:
@@ -136,13 +136,13 @@ ca:
         filters:
           search: Cerca
         collaboration:
-          donate: Donar suport
+          support: Donar suport
         totals:
           overall_totals: Acumulat
           user_totals: Usuari
           target_amount: "Objetiu: %{amount}"
           overall_percentage: Percentatge total
-        donate_form:
+        support_form:
           select_amount: Sel·lecciona la quantitat
           select_frequency: Sel·lecciona la frequència
           select_payment_method: Sel·lecciona la forma de pagament

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -63,7 +63,7 @@ ca:
           monthly: Mensual
           quarterly: Trimestral
           annual: Anual
-        donate_status:
+        support_status:
           collaboration_not_allowed: La col·laboració no está permesa en estos moments.
           maximum_annual_exceeded: No pots realitzar mes col·laboracions. Has arribat al màxim anual permés.
           support_period_finished: El periode per a realitzar colaboracions ha finalitzat.
@@ -146,9 +146,9 @@ ca:
           select_amount: Sel·lecciona la quantitat
           select_frequency: Sel·lecciona la frequència
           select_payment_method: Sel·lecciona la forma de pagament
-          donate: Donar suport
+          support: Donar suport
         sign_in:
-          donate: Donar suport
+          support: Donar suport
       user_collaborations:
         create:
           invalid: L'operació ha fallat.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -44,7 +44,7 @@ en:
         accept_terms_and_conditions: I accept all the terms and conditions
   decidim:
     form_builder:
-      donate_tag:
+      support_tag:
         other: Other
     features:
       collaborations:
@@ -122,7 +122,7 @@ en:
             success: The collaboration campaign has been successfully erased.
           form:
             amounts_help: Type the valid amounts. Separe the values with comas.
-            active_until_help: This date must be inside the participatory process phases. In case a phase do not accepts donations it will be ignored and thus not applied.
+            active_until_help: This date must be inside the participatory process phases. In case a phase do not accepts supports it will be ignored and thus not applied.
       collaborations:
         count:
           collaborations_count:
@@ -136,13 +136,13 @@ en:
         filters:
           search: Search
         collaboration:
-          donate: Support
+          support: Support
         totals:
           overall_totals: Overall totals
           user_totals: User totals
           target_amount: "Target amount: %{amount}"
           overall_percentage: Overall percentage
-        donate_form:
+        support_form:
           select_amount: Select the amount
           select_frequency: Select the frequency
           select_payment_method: Select the payment method

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -63,7 +63,7 @@ en:
           monthly: Monthly
           quarterly: Quarterly
           annual: Annual
-        donate_status:
+        support_status:
           collaboration_not_allowed: Collaboration is not allowed at this moment.
           maximum_annual_exceeded: You can not create more collaborations. You have reached the maximum yearly allowed.
           support_period_finished: The period for accepting collaborations has expired.
@@ -146,9 +146,9 @@ en:
           select_amount: Select the amount
           select_frequency: Select the frequency
           select_payment_method: Select the payment method
-          donate: Support
+          support: Support
         sign_in:
-          donate: Support
+          support: Support
       user_collaborations:
         create:
           invalid: Operation failed.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -44,7 +44,7 @@ es:
         accept_terms_and_conditions: Acepto los términos y condiciones
   decidim:
     form_builder:
-      donate_tag:
+      support_tag:
         other: Otros
     features:
       collaborations:
@@ -136,13 +136,13 @@ es:
         filters:
           search: Buscar
         collaboration:
-          donate: Apoyar
+          support: Apoyar
         totals:
           overall_totals: Acumulado
           user_totals: Usuario
           target_amount: "Objetivo: %{amount}"
           overall_percentage: Porcentaje total
-        donate_form:
+        support_form:
           select_amount: Seleccciona la cantidad
           select_frequency: Seleccciona la frequencia
           select_payment_method: Selecciona la forma de pago

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -63,7 +63,7 @@ es:
           monthly: Mensual
           quarterly: Trimestral
           annual: Anual
-        donate_status:
+        support_status:
           collaboration_not_allowed: La colaboración no está permitida en estos momentos.
           maximum_annual_exceeded: No puedes realizar mas colaboraciones. Has alcanzado el máximo anual permitido.
           support_period_finished: El periodo para realizar colaboraciones ha concluido.
@@ -146,9 +146,9 @@ es:
           select_amount: Seleccciona la cantidad
           select_frequency: Seleccciona la frequencia
           select_payment_method: Selecciona la forma de pago
-          donate: Apoyar
+          support: Apoyar
         sign_in:
-          donate: Apoyar
+          support: Apoyar
       user_collaborations:
         create:
           invalid: Falló la operación.

--- a/lib/decidim/collaborations/form_builder.rb
+++ b/lib/decidim/collaborations/form_builder.rb
@@ -7,7 +7,7 @@ module Decidim
       include ::ActionView::Helpers::FormTagHelper
       include ::ActionView::Helpers::NumberHelper
 
-      def donate_tag(name, amounts)
+      def support_tag(name, amounts)
         amount_selector_tag(name, amounts) + amount_input_tag(name)
       end
 
@@ -29,7 +29,7 @@ module Decidim
 
         content_tag :label, for: "#{name}_selector_other" do
           concat radio_button_tag "#{name}_selector".to_sym, 'other', checked
-          concat amount_label(I18n.t('donate_tag.other', scope: 'decidim.form_builder'))
+          concat amount_label(I18n.t('support_tag.other', scope: 'decidim.form_builder'))
         end
       end
 

--- a/spec/models/decidim/collaborations/abilities/current_user_ability_spec.rb
+++ b/spec/models/decidim/collaborations/abilities/current_user_ability_spec.rb
@@ -19,32 +19,32 @@ describe Decidim::Collaborations::Abilities::CurrentUserAbility do
                                   .and_return(collaborations_allowed)
   end
 
-  context 'donate to collaboration' do
+  context 'support collaboration' do
     context 'collaboration allowed' do
       let(:collaborations_allowed) { true }
 
-      it 'let the user donate when collaboration accepts donations' do
-        expect(collaboration).to receive(:accepts_donations?).and_return(true)
-        expect(subject).to be_able_to(:donate, collaboration)
+      it 'let the user support when collaboration accepts supports' do
+        expect(collaboration).to receive(:accepts_supports?).and_return(true)
+        expect(subject).to be_able_to(:support, collaboration)
       end
 
-      it 'Do not let the user donate when collaboration do not accepts donations' do
-        expect(collaboration).to receive(:accepts_donations?).and_return(false)
-        expect(subject).not_to be_able_to(:donate, collaboration)
+      it 'Do not let the user support when collaboration do not accepts supports' do
+        expect(collaboration).to receive(:accepts_supports?).and_return(false)
+        expect(subject).not_to be_able_to(:support, collaboration)
       end
     end
 
     context 'collaboration not allowed' do
       let(:collaborations_allowed) { false }
 
-      it 'do not let the user donate when collaboration accepts donations' do
-        expect(collaboration).to receive(:accepts_donations?).and_return(true)
-        expect(subject).not_to be_able_to(:donate, collaboration)
+      it 'do not let the user support when collaboration accepts supports' do
+        expect(collaboration).to receive(:accepts_supports?).and_return(true)
+        expect(subject).not_to be_able_to(:support, collaboration)
       end
 
-      it 'Do not let the user donate when collaboration do not accepts donations' do
-        expect(collaboration).to receive(:accepts_donations?).and_return(false)
-        expect(subject).not_to be_able_to(:donate, collaboration)
+      it 'Do not let the user support when collaboration do not accepts supports' do
+        expect(collaboration).to receive(:accepts_supports?).and_return(false)
+        expect(subject).not_to be_able_to(:support, collaboration)
       end
     end
 
@@ -52,39 +52,39 @@ describe Decidim::Collaborations::Abilities::CurrentUserAbility do
       context 'User is in the limit' do
         let(:user_annual_accumulated) { Decidim::Collaborations.maximum_annual_collaboration }
 
-        it 'User is not allowed to donate' do
-          expect(subject).not_to be_able_to(:donate, collaboration)
+        it 'User is not allowed to support' do
+          expect(subject).not_to be_able_to(:support, collaboration)
         end
       end
 
       context 'User is under the limit' do
         let(:user_annual_accumulated) { 0 }
 
-        it 'User is allowed to donate' do
-          expect(subject).to be_able_to(:donate, collaboration)
+        it 'User is allowed to support' do
+          expect(subject).to be_able_to(:support, collaboration)
         end
       end
     end
   end
 
-  context 'donate_recurrently' do
-    context 'First user recurrent collaboration' do
+  context 'support_recurrently' do
+    context 'First user recurrent support' do
       before do
-        allow(collaboration).to receive(:recurrent_donation_allowed?).and_return(true)
+        allow(collaboration).to receive(:recurrent_support_allowed?).and_return(true)
       end
 
-      it 'User can do a recurrent donation' do
-        expect(subject).to be_able_to(:donate_recurrently, collaboration)
+      it 'User can do a recurrent support' do
+        expect(subject).to be_able_to(:support_recurrently, collaboration)
       end
     end
 
-    context 'User already has a recurrent collaboration' do
+    context 'User already has a recurrent support' do
       let!(:user_collaboration) do
         create(:user_collaboration, :monthly, :accepted, collaboration: collaboration)
       end
 
-      it 'User can not do a recurrent donation' do
-        expect(subject).not_to be_able_to(:donate_recurrently, collaboration)
+      it 'User can not do a recurrent support' do
+        expect(subject).not_to be_able_to(:support_recurrently, collaboration)
       end
     end
   end

--- a/spec/models/decidim/collaborations/abilities/guest_user_ability_spec.rb
+++ b/spec/models/decidim/collaborations/abilities/guest_user_ability_spec.rb
@@ -16,32 +16,32 @@ describe Decidim::Collaborations::Abilities::GuestUserAbility do
                                   .and_return(collaborations_allowed)
   end
 
-  context 'donate to collaboration' do
+  context 'support collaboration' do
     context 'collaboration allowed' do
       let(:collaborations_allowed) { true }
 
-      it 'let the user donate when collaboration accepts donations' do
-        expect(collaboration).to receive(:accepts_donations?).and_return(true)
-        expect(subject).to be_able_to(:donate, collaboration)
+      it 'when collaboration accepts supports' do
+        expect(collaboration).to receive(:accepts_supports?).and_return(true)
+        expect(subject).to be_able_to(:support, collaboration)
       end
 
-      it 'Do not let the user donate when collaboration do not accepts donations' do
-        expect(collaboration).to receive(:accepts_donations?).and_return(false)
-        expect(subject).not_to be_able_to(:donate, collaboration)
+      it 'when collaboration do not accepts supports' do
+        expect(collaboration).to receive(:accepts_supports?).and_return(false)
+        expect(subject).not_to be_able_to(:support, collaboration)
       end
     end
 
     context 'collaboration not allowed' do
       let(:collaborations_allowed) { false }
 
-      it 'do not let the user donate when collaboration accepts donations' do
-        expect(collaboration).to receive(:accepts_donations?).and_return(true)
-        expect(subject).not_to be_able_to(:donate, collaboration)
+      it 'when collaboration accepts supports' do
+        expect(collaboration).to receive(:accepts_supports?).and_return(true)
+        expect(subject).not_to be_able_to(:support, collaboration)
       end
 
-      it 'Do not let the user donate when collaboration do not accepts donations' do
-        expect(collaboration).to receive(:accepts_donations?).and_return(false)
-        expect(subject).not_to be_able_to(:donate, collaboration)
+      it 'when collaboration do not accepts supports' do
+        expect(collaboration).to receive(:accepts_supports?).and_return(false)
+        expect(subject).not_to be_able_to(:support, collaboration)
       end
     end
   end

--- a/spec/models/decidim/collaborations/collaboration_spec.rb
+++ b/spec/models/decidim/collaborations/collaboration_spec.rb
@@ -16,7 +16,7 @@ module Decidim
         it { is_expected.not_to be_valid }
       end
 
-      context 'accepts_donations?' do
+      context 'accepts_supports?' do
         let(:active_until) { nil }
         let(:target_amount) { 10_000 }
         let(:total_collected) { 0 }
@@ -34,7 +34,7 @@ module Decidim
           let(:active_until) { DateTime.now - 1.day }
 
           it 'returns false' do
-            expect(collaboration.accepts_donations?).to be_falsey
+            expect(collaboration.accepts_supports?).to be_falsey
           end
         end
 
@@ -42,7 +42,7 @@ module Decidim
           let(:total_collected) { target_amount }
 
           it 'returns false' do
-            expect(collaboration.accepts_donations?).to be_falsey
+            expect(collaboration.accepts_supports?).to be_falsey
           end
         end
 
@@ -52,7 +52,7 @@ module Decidim
           end
 
           it 'returns false' do
-            expect(collaboration.accepts_donations?).to be_falsey
+            expect(collaboration.accepts_supports?).to be_falsey
           end
         end
 
@@ -170,20 +170,20 @@ module Decidim
         end
       end
 
-      context 'recurrent_donation_allowed?' do
+      context 'recurrent_support_allowed?' do
         let(:collaboration) { create :collaboration }
 
         context 'assemblies' do
           let(:collaboration) { create :collaboration, :assembly }
 
-          it 'accept recurrent donations' do
-            expect(subject).to  be_recurrent_donation_allowed
+          it 'accept recurrent supports' do
+            expect(subject).to  be_recurrent_support_allowed
           end
         end
 
         context 'participatory process' do
-          it "don't accept recurrent donations" do
-            expect(subject).not_to  be_recurrent_donation_allowed
+          it "don't accept recurrent supports" do
+            expect(subject).not_to  be_recurrent_support_allowed
           end
         end
       end


### PR DESCRIPTION
Any trace of the word donate has been removed from the project.

#### :tophat: What? Why?
From a purely legal perspective a donation is different of a collaboration. To avoid any confussion the word donate and any of its derivatives has been replaced in the project by the word support.

#### :pushpin: Related Issues
- Fixes #10 
